### PR TITLE
bug-fix(command/pull-schema): path is not defined

### DIFF
--- a/commands/pull-schema.js
+++ b/commands/pull-schema.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import fs from 'fs'
+import path from 'path'
 import _debug from 'debug'
 import { print } from 'graphql'
 import { performance } from 'perf_hooks'


### PR DESCRIPTION
Fixes `ReferenceError: path is not defined` when using the pull-schema command.